### PR TITLE
Optionally use an identity provider for user certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SSH Term Release Notes
 
+## next
+
+### :star2: New features
+
+* Add an option to automatically fetch and refresh user certificates from an identity provider. This feature is intended to be used with tlsproxy's built-in SSH Certificate Authority. See `keys generate -h`
+
 ## v0.5.1
 
 ### :star: Feature improvements

--- a/go/internal/app/app.go
+++ b/go/internal/app/app.go
@@ -62,9 +62,9 @@ func New(cfg *Config) (*App, error) {
 		agent: &keyRing{},
 		data: appData{
 			Persist:     true,
-			Endpoints:   make(map[string]endpoint),
+			Endpoints:   make(map[string]*endpoint),
 			Keys:        make(map[string]*key),
-			Authorities: make(map[string]authority),
+			Authorities: make(map[string]*authority),
 		},
 		inShell: new(atomic.Bool),
 	}
@@ -123,10 +123,10 @@ type App struct {
 }
 
 type appData struct {
-	Persist     bool                 `json:"persist"`
-	Endpoints   map[string]endpoint  `json:"endpoints"`
-	Keys        map[string]*key      `json:"keys"`
-	Authorities map[string]authority `json:"authorities"`
+	Persist     bool                  `json:"persist"`
+	Endpoints   map[string]*endpoint  `json:"endpoints"`
+	Keys        map[string]*key       `json:"keys"`
+	Authorities map[string]*authority `json:"authorities"`
 }
 
 type endpoint struct {

--- a/go/internal/app/ca.go
+++ b/go/internal/app/ca.go
@@ -54,7 +54,7 @@ func (a *App) caCommand() *cli.App {
 						a.term.Printf("<none>\n")
 						return nil
 					}
-					cas := make([]authority, 0, len(a.data.Authorities))
+					cas := make([]*authority, 0, len(a.data.Authorities))
 					for _, ca := range a.data.Authorities {
 						cas = append(cas, ca)
 					}
@@ -114,7 +114,7 @@ func (a *App) caCommand() *cli.App {
 						return err
 					}
 					fp := ssh.FingerprintSHA256(key)
-					a.data.Authorities[fp] = authority{
+					a.data.Authorities[fp] = &authority{
 						Name:        name,
 						Fingerprint: fp,
 						Public:      key.Marshal(),

--- a/go/internal/app/db.go
+++ b/go/internal/app/db.go
@@ -39,7 +39,6 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/crypto/pbkdf2"
-	"golang.org/x/crypto/ssh/agent"
 )
 
 func (a *App) dbCommand() *cli.App {
@@ -101,9 +100,9 @@ func (a *App) dbCommand() *cli.App {
 					if !a.term.Confirm("You are about to WIPE the database.\nContinue? ", false) {
 						return errors.New("aborted")
 					}
-					a.agent = agent.NewKeyring()
+					a.agent = &keyRing{}
 					a.data.Endpoints = make(map[string]endpoint)
-					a.data.Keys = make(map[string]key)
+					a.data.Keys = make(map[string]*key)
 					a.data.Authorities = make(map[string]authority)
 					if err := a.saveAll(); err != nil {
 						return err
@@ -210,7 +209,7 @@ func (a *App) dbCommand() *cli.App {
 					if !ok {
 						return fmt.Errorf("unable to decrypt file")
 					}
-					a.agent = agent.NewKeyring()
+					a.agent = &keyRing{}
 					a.data.Endpoints = nil
 					a.data.Keys = nil
 					if err := json.Unmarshal(payload, &a.data); err != nil {

--- a/go/internal/app/db.go
+++ b/go/internal/app/db.go
@@ -101,9 +101,9 @@ func (a *App) dbCommand() *cli.App {
 						return errors.New("aborted")
 					}
 					a.agent = &keyRing{}
-					a.data.Endpoints = make(map[string]endpoint)
+					a.data.Endpoints = make(map[string]*endpoint)
 					a.data.Keys = make(map[string]*key)
-					a.data.Authorities = make(map[string]authority)
+					a.data.Authorities = make(map[string]*authority)
 					if err := a.saveAll(); err != nil {
 						return err
 					}

--- a/go/internal/app/ep.go
+++ b/go/internal/app/ep.go
@@ -87,7 +87,7 @@ func (a *App) epCommand() *cli.App {
 						return errors.New("endpoint name cannot contain \":\"")
 					}
 					url := ctx.Args().Get(1)
-					a.data.Endpoints[name] = endpoint{Name: name, URL: url}
+					a.data.Endpoints[name] = &endpoint{Name: name, URL: url}
 					return a.saveEndpoints()
 				},
 			},

--- a/go/internal/app/keys.go
+++ b/go/internal/app/keys.go
@@ -496,7 +496,7 @@ func (k *key) updateCert() error {
 	req.Header.Set("x-csrf-check", "1")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("%q: %w", err)
+		return fmt.Errorf("%q: %v", k.Provider, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK || resp.Header.Get("Content-Type") != "text/plain" {
@@ -508,10 +508,10 @@ func (k *key) updateCert() error {
 	}
 	certBytes, err := io.ReadAll(&io.LimitedReader{R: resp.Body, N: 20480})
 	if err != nil {
-		return fmt.Errorf("%q: %w", err)
+		return fmt.Errorf("%q: %v", k.Provider, err)
 	}
 	if _, _, _, _, err := ssh.ParseAuthorizedKey(certBytes); err != nil {
-		return fmt.Errorf("%q: %w", err)
+		return fmt.Errorf("%q: %v", k.Provider, err)
 	}
 	k.CertBytes = certBytes
 	return nil


### PR DESCRIPTION
This change adds a flag to `keys generate` to automatically fetch and refresh user certificates for this key from an identity provider.
    
This feature is intended to be used with tlsproxy's built-in SSH Certificate Authority.