### PR TITLE
Read preset values from config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### :star2: New features
 
 * Add an option to automatically fetch and refresh user certificates from an identity provider. This feature is intended to be used with tlsproxy's built-in SSH Certificate Authority. See `keys generate -h`
+* Read a preset configuration from config.json, if present. See `config/config.go` and `docroot/config.json.example`.
 
 ## v0.5.1
 

--- a/docroot/.gitignore
+++ b/docroot/.gitignore
@@ -1,1 +1,2 @@
 LICENSE*
+config.json

--- a/docroot/config.json.example
+++ b/docroot/config.json.example
@@ -1,0 +1,24 @@
+{
+	"persist": false,
+	"certificateAuthorities": [{
+		"name": "my_ca_example_com",
+		"publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOO4jC9AcVsCOfapTGboTKOuMbil0Z8jKnt3pb3M8eqi",
+		"hostnames": [ "*.example.com" ]
+	}],
+	"endpoints": [{
+		"name": "myserver.example.com",
+		"url": "./websocket",
+		"hostKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINqyuT/sFvC37z1qMY0may2TMKqg2nxdjxBxyfXeieot"
+	}],
+	"generateKeys": [{
+		"name": "default",
+		"type": "ed25519",
+		"identityProvider": "./cert"
+	}],
+	"autoConnect": {
+		"username": "username",
+		"endpoint": "myserver.example.com",
+		"identity": "default",
+		"command": "uname -a"
+	}
+}

--- a/docroot/config.json.example
+++ b/docroot/config.json.example
@@ -13,12 +13,14 @@
 	"generateKeys": [{
 		"name": "default",
 		"type": "ed25519",
-		"identityProvider": "./cert"
+		"identityProvider": "./cert",
+		"addToAgent": true
 	}],
 	"autoConnect": {
 		"username": "username",
 		"endpoint": "myserver.example.com",
 		"identity": "default",
-		"command": "uname -a"
+		"command": "uname -a",
+		"forwardAgent": false
 	}
 }

--- a/docroot/config.json.example
+++ b/docroot/config.json.example
@@ -8,7 +8,10 @@
 	"endpoints": [{
 		"name": "myserver.example.com",
 		"url": "./websocket",
-		"hostKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINqyuT/sFvC37z1qMY0may2TMKqg2nxdjxBxyfXeieot"
+	}],
+	"hosts": [{
+		"name": "myserver.example.com",
+		"key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINqyuT/sFvC37z1qMY0may2TMKqg2nxdjxBxyfXeieot"
 	}],
 	"generateKeys": [{
 		"name": "default",

--- a/docroot/ssh.js
+++ b/docroot/ssh.js
@@ -79,12 +79,28 @@ window.addEventListener('load', () => {
   window.addEventListener('resize', () => fitAddon.fit())
   fitAddon.fit();
   sshApp.term = term;
-  sshApp.ready
-    .then(() => sshApp.start({term}))
+  Promise.all([
+    sshApp.ready,
+    fetch('config.json')
+    .then(r => {
+      if (r.ok) return r.json();
+      return {};
+    })
+    .catch(e => {
+      term.writeln('\x1b[31mError reading config.json:\x1b[0m');
+      term.writeln('\x1b[31m'+e.message+'\x1b[0m');
+      term.writeln('');
+      return {};
+    }),
+  ]).then(v => {
+    let cfg = v[1];
+    cfg.term = term;
+    sshApp.start(cfg)
     .then(v => sshApp.onExit(v))
     .catch(e => {
       console.log('SSH ERROR', e);
       term.writeln(e.message);
       sshApp.onExit(e.message);
     });
+  });
 });

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -59,6 +59,7 @@ type Config struct {
 		Type             string `json:"type,omitempty"`
 		Bits             int    `json:"bits,omitempty"`
 		IdentityProvider string `json:"identityProvider,omitempty"`
+		AddToAgent       bool   `json:"addToAgent,omitempty"`
 	} `json:"generateKeys,omitempty"`
 
 	// AutoConnect, if set, instructs the app to open an SSH connection
@@ -67,9 +68,10 @@ type Config struct {
 	// If Username is unset, the user will be prompted to enter it.
 	// If Command is unset, the app will request an interactive shell.
 	AutoConnect *struct {
-		Username string `json:"username,omitempty"`
-		Endpoint string `json:"endpoint"`
-		Identity string `json:"identity,omitempty"`
-		Command  string `json:"command,omitempty"`
+		Username     string `json:"username,omitempty"`
+		Endpoint     string `json:"endpoint"`
+		Identity     string `json:"identity,omitempty"`
+		Command      string `json:"command,omitempty"`
+		ForwardAgent bool   `json:"forwardAgent,omitempty"`
 	} `json:"autoConnect,omitempty"`
 }

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -1,0 +1,75 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package config
+
+// Config is SSH Term configuration. This data structure is typically read from
+// the config.json file in the same directory as the SSH app.
+type Config struct {
+	// DBName is the name of the IndexedDB database to use. It defaults to
+	// "sshterm".
+	DBName string `json:"dbName,omitempty"`
+
+	// Persist, if set, forces database persistence to be on or off and
+	// cannot be changed from the app.
+	Persist *bool `json:"persist,omitempty"`
+
+	// Authorities is a list of Certificate Authorities used to verify host
+	// certificates.
+	Authorities []struct {
+		Name      string   `json:"name"`
+		PublicKey string   `json:"publicKey"`
+		Hostnames []string `json:"hostnames,omitempty"`
+	} `json:"certificateAuthorities,omitempty"`
+
+	// Endpoints is a list of WebSocket endpoints that the app can use to
+	// connect to SSH servers.
+	// The HostKey should be left unset if the server uses a certificate.
+	Endpoints []struct {
+		Name    string `json:"name"`
+		URL     string `json:"url"`
+		HostKey string `json:"hostKey,omitempty"`
+	} `json:"endpoints,omitempty"`
+
+	// GenerateKeys instructs the app to generate SSH keys when it starts.
+	// These keys are passwordless and are intended to be used with an
+	// Identity Provider.
+	GenerateKeys []struct {
+		Name             string `json:"name"`
+		Type             string `json:"type,omitempty"`
+		Bits             int    `json:"bits,omitempty"`
+		IdentityProvider string `json:"identityProvider,omitempty"`
+	} `json:"generateKeys,omitempty"`
+
+	// AutoConnect, if set, instructs the app to open an SSH connection
+	// immediately after it starts. All normal interactive commands are
+	// disabled.
+	// If Username is unset, the user will be prompted to enter it.
+	// If Command is unset, the app will request an interactive shell.
+	AutoConnect *struct {
+		Username string `json:"username,omitempty"`
+		Endpoint string `json:"endpoint"`
+		Identity string `json:"identity,omitempty"`
+		Command  string `json:"command,omitempty"`
+	} `json:"autoConnect,omitempty"`
+}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -44,12 +44,18 @@ type Config struct {
 
 	// Endpoints is a list of WebSocket endpoints that the app can use to
 	// connect to SSH servers.
-	// The HostKey should be left unset if the server uses a certificate.
 	Endpoints []struct {
-		Name    string `json:"name"`
-		URL     string `json:"url"`
-		HostKey string `json:"hostKey,omitempty"`
+		Name string `json:"name"`
+		URL  string `json:"url"`
 	} `json:"endpoints,omitempty"`
+
+	// Hosts is a list of known hosts and their host keys. It is used for
+	// host key authentication. For hosts that use certificates, use
+	// Authorities instead.
+	Hosts []struct {
+		Name string `json:"name"`
+		Key  string `json:"key,omitempty"`
+	} `json:"hosts,omitempty"`
 
 	// GenerateKeys instructs the app to generate SSH keys when it starts.
 	// These keys are passwordless and are intended to be used with an

--- a/go/internal/app/app.go
+++ b/go/internal/app/app.go
@@ -224,10 +224,11 @@ func (a *App) Run() error {
 	if a.cfg.AutoConnect != nil {
 		jsutil.TryCatch(
 			func() { // try
-				for a.cfg.AutoConnect.Username == "" {
-					a.cfg.AutoConnect.Username, _ = t.Prompt("Username: ")
+				username := a.cfg.AutoConnect.Username
+				for username == "" {
+					username, _ = t.Prompt("Username: ")
 				}
-				target := a.cfg.AutoConnect.Username + "@" + a.cfg.AutoConnect.Endpoint
+				target := username + "@" + a.cfg.AutoConnect.Endpoint
 				if err := a.runSSH(ctx, target, a.cfg.AutoConnect.Identity, a.cfg.AutoConnect.Command, false); err != nil {
 					t.Errorf("%v", err)
 				}

--- a/go/internal/app/ca.go
+++ b/go/internal/app/ca.go
@@ -42,6 +42,11 @@ func (a *App) addAuthority(name, publicKey string, hostnames []string) error {
 		return err
 	}
 	fp := ssh.FingerprintSHA256(key)
+	for k, v := range a.data.Authorities {
+		if v.Name == name {
+			delete(a.data.Authorities, k)
+		}
+	}
 	a.data.Authorities[fp] = &authority{
 		Name:        name,
 		Fingerprint: fp,

--- a/go/internal/app/ca.go
+++ b/go/internal/app/ca.go
@@ -36,6 +36,21 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+func (a *App) addAuthority(name, publicKey string, hostnames []string) error {
+	key, _, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
+	if err != nil {
+		return err
+	}
+	fp := ssh.FingerprintSHA256(key)
+	a.data.Authorities[fp] = &authority{
+		Name:        name,
+		Fingerprint: fp,
+		Public:      key.Marshal(),
+		Hostnames:   hostnames,
+	}
+	return nil
+}
+
 func (a *App) caCommand() *cli.App {
 	return &cli.App{
 		Name:            "ca",
@@ -109,16 +124,8 @@ func (a *App) caCommand() *cli.App {
 					if err != nil {
 						return fmt.Errorf("%q: %w", f.Name, err)
 					}
-					key, _, _, _, err := ssh.ParseAuthorizedKey(content)
-					if err != nil {
+					if err := a.addAuthority(name, string(content), ctx.Args().Slice()[1:]); err != nil {
 						return err
-					}
-					fp := ssh.FingerprintSHA256(key)
-					a.data.Authorities[fp] = &authority{
-						Name:        name,
-						Fingerprint: fp,
-						Public:      key.Marshal(),
-						Hostnames:   ctx.Args().Slice()[1:],
 					}
 					if err := a.saveAuthorities(); err != nil {
 						return err

--- a/go/internal/app/db.go
+++ b/go/internal/app/db.go
@@ -42,7 +42,7 @@ import (
 )
 
 func (a *App) dbCommand() *cli.App {
-	return &cli.App{
+	ret := &cli.App{
 		Name:            "db",
 		Usage:           "Manage database",
 		UsageText:       "db <persist|wipe|backup|restore>",
@@ -58,7 +58,7 @@ func (a *App) dbCommand() *cli.App {
 						cli.ShowSubcommandHelp(ctx)
 						return nil
 					}
-					if ctx.Args().Len() == 1 {
+					if ctx.Args().Len() == 1 && a.cfg.Persist == nil {
 						switch v := ctx.Args().Get(0); v {
 						case "on":
 							a.data.Persist = true
@@ -220,4 +220,9 @@ func (a *App) dbCommand() *cli.App {
 			},
 		},
 	}
+	if a.cfg.Persist != nil {
+		ret.Commands[0].Usage = "Show the database persistence to local storage."
+		ret.Commands[0].UsageText = "db persist"
+	}
+	return ret
 }

--- a/go/internal/app/db.go
+++ b/go/internal/app/db.go
@@ -101,9 +101,10 @@ func (a *App) dbCommand() *cli.App {
 						return errors.New("aborted")
 					}
 					a.agent = &keyRing{}
-					a.data.Endpoints = make(map[string]*endpoint)
-					a.data.Keys = make(map[string]*key)
 					a.data.Authorities = make(map[string]*authority)
+					a.data.Endpoints = make(map[string]*endpoint)
+					a.data.Hosts = make(map[string]*host)
+					a.data.Keys = make(map[string]*key)
 					if err := a.saveAll(); err != nil {
 						return err
 					}

--- a/go/internal/app/ep.go
+++ b/go/internal/app/ep.go
@@ -34,6 +34,15 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+func (a *App) addEndpoint(name, url, hostKey string) error {
+	var hk []byte
+	if key, _, _, _, err := ssh.ParseAuthorizedKey([]byte(hostKey)); err == nil {
+		hk = key.Marshal()
+	}
+	a.data.Endpoints[name] = &endpoint{Name: name, URL: url, HostKey: hk}
+	return nil
+}
+
 func (a *App) epCommand() *cli.App {
 	return &cli.App{
 		Name:            "ep",
@@ -87,7 +96,9 @@ func (a *App) epCommand() *cli.App {
 						return errors.New("endpoint name cannot contain \":\"")
 					}
 					url := ctx.Args().Get(1)
-					a.data.Endpoints[name] = &endpoint{Name: name, URL: url}
+					if err := a.addEndpoint(name, url, ""); err != nil {
+						return err
+					}
 					return a.saveEndpoints()
 				},
 			},

--- a/go/internal/app/ep.go
+++ b/go/internal/app/ep.go
@@ -34,12 +34,8 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func (a *App) addEndpoint(name, url, hostKey string) error {
-	var hk []byte
-	if key, _, _, _, err := ssh.ParseAuthorizedKey([]byte(hostKey)); err == nil {
-		hk = key.Marshal()
-	}
-	a.data.Endpoints[name] = &endpoint{Name: name, URL: url, HostKey: hk}
+func (a *App) addEndpoint(name, url string) error {
+	a.data.Endpoints[name] = &endpoint{Name: name, URL: url}
 	return nil
 }
 
@@ -73,8 +69,10 @@ func (a *App) epCommand() *cli.App {
 					for _, n := range names {
 						ep := a.data.Endpoints[n]
 						fp := "n/a"
-						if key, err := ssh.ParsePublicKey(ep.HostKey); err == nil {
-							fp = ssh.FingerprintSHA256(key)
+						if host, exists := a.data.Hosts[n]; exists && host.Key != nil {
+							if key, err := ssh.ParsePublicKey(host.Key); err == nil {
+								fp = ssh.FingerprintSHA256(key)
+							}
 						}
 						a.term.Printf("%*s %*s %s\n", -szName, ep.Name, -szURL, ep.URL, fp)
 					}
@@ -96,7 +94,7 @@ func (a *App) epCommand() *cli.App {
 						return errors.New("endpoint name cannot contain \":\"")
 					}
 					url := ctx.Args().Get(1)
-					if err := a.addEndpoint(name, url, ""); err != nil {
+					if err := a.addEndpoint(name, url); err != nil {
 						return err
 					}
 					return a.saveEndpoints()

--- a/go/internal/app/hosts.go
+++ b/go/internal/app/hosts.go
@@ -1,0 +1,97 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build wasm
+
+package app
+
+import (
+	"sort"
+
+	"github.com/urfave/cli/v2"
+	"golang.org/x/crypto/ssh"
+)
+
+func (a *App) addHost(name, key string) error {
+	var hk []byte
+	if key, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key)); err == nil {
+		hk = key.Marshal()
+	}
+	a.data.Hosts[name] = &host{Name: name, Key: hk}
+	return nil
+}
+
+func (a *App) hostsCommand() *cli.App {
+	return &cli.App{
+		Name:            "hosts",
+		Usage:           "Manage known hosts",
+		UsageText:       "hosts <list|delete>",
+		Description:     "The hosts command is used to manage known hosts.",
+		HideHelpCommand: true,
+		DefaultCommand:  "list",
+		Commands: []*cli.Command{
+			{
+				Name:      "list",
+				Usage:     "List all known hosts",
+				UsageText: "hosts list",
+				Action: func(ctx *cli.Context) error {
+					if len(a.data.Hosts) == 0 {
+						a.term.Printf("<none>\n")
+						return nil
+					}
+					names := make([]string, 0, len(a.data.Hosts))
+					szName := 5
+					for _, host := range a.data.Hosts {
+						names = append(names, host.Name)
+						szName = max(szName, len(host.Name))
+					}
+					sort.Strings(names)
+					a.term.Printf("%*s %s\n", -szName, "Name", "Host key fingerprint")
+					for _, n := range names {
+						host := a.data.Hosts[n]
+						fp := "n/a"
+						if key, err := ssh.ParsePublicKey(host.Key); err == nil {
+							fp = ssh.FingerprintSHA256(key)
+						}
+						a.term.Printf("%*s %s\n", -szName, host.Name, fp)
+					}
+					return nil
+				},
+			},
+			{
+				Name:      "delete",
+				Usage:     "Delete a known host",
+				UsageText: "hosts delete <name>",
+				Action: func(ctx *cli.Context) error {
+					if ctx.Args().Len() != 1 {
+						cli.ShowSubcommandHelp(ctx)
+						return nil
+					}
+					name := ctx.Args().Get(0)
+					delete(a.data.Hosts, name)
+					return a.saveHosts()
+				},
+			},
+		},
+	}
+}

--- a/go/internal/app/keys.go
+++ b/go/internal/app/keys.go
@@ -366,7 +366,7 @@ func (a *App) keysCommand() *cli.App {
 
 func createKey(t string, b int) (crypto.PublicKey, crypto.PrivateKey, error) {
 	switch t {
-	case "ed25519":
+	case "ed25519", "":
 		return ed25519.GenerateKey(rand.Reader)
 
 	case "ecdsa":

--- a/go/internal/app/keys.go
+++ b/go/internal/app/keys.go
@@ -47,6 +47,33 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+func (a *App) generateKey(name, passphrase, idp, typ string, bits int) error {
+	pub, priv, err := createKey(typ, bits)
+	if err != nil {
+		return err
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return fmt.Errorf("ssh.NewPublicKey: %w", err)
+	}
+	var privPEM *pem.Block
+	if passphrase == "" {
+		if privPEM, err = ssh.MarshalPrivateKey(priv, ""); err != nil {
+			return fmt.Errorf("ssh.MarshalPrivateKey: %w", err)
+		}
+	} else if privPEM, err = ssh.MarshalPrivateKeyWithPassphrase(priv, "", []byte(passphrase)); err != nil {
+		return fmt.Errorf("ssh.MarshalPrivateKeyWithPassphrase: %w", err)
+	}
+	a.data.Keys[name] = &key{
+		Name:     name,
+		Public:   sshPub.Marshal(),
+		Private:  pem.EncodeToMemory(privPEM),
+		Provider: idp,
+		errorf:   a.term.Errorf,
+	}
+	return nil
+}
+
 func (a *App) keysCommand() *cli.App {
 	return &cli.App{
 		Name:            "keys",
@@ -111,14 +138,6 @@ func (a *App) keysCommand() *cli.App {
 						return nil
 					}
 					name := ctx.Args().Get(0)
-					pub, priv, err := createKey(ctx.String("type"), ctx.Int("bits"))
-					if err != nil {
-						return err
-					}
-					sshPub, err := ssh.NewPublicKey(pub)
-					if err != nil {
-						return fmt.Errorf("ssh.NewPublicKey: %w", err)
-					}
 					passphrase, err := a.term.ReadPassword("Enter passphrase for private key: ")
 					if err != nil {
 						return fmt.Errorf("ReadPassword: %w", err)
@@ -130,20 +149,9 @@ func (a *App) keysCommand() *cli.App {
 					if passphrase != passphrase2 {
 						return fmt.Errorf("passphrase doesn't match")
 					}
-					var privPEM *pem.Block
-					if passphrase == "" {
-						if privPEM, err = ssh.MarshalPrivateKey(priv, ""); err != nil {
-							return fmt.Errorf("ssh.MarshalPrivateKey: %w", err)
-						}
-					} else if privPEM, err = ssh.MarshalPrivateKeyWithPassphrase(priv, "", []byte(passphrase)); err != nil {
-						return fmt.Errorf("ssh.MarshalPrivateKeyWithPassphrase: %w", err)
-					}
-					a.data.Keys[name] = &key{
-						Name:     name,
-						Public:   sshPub.Marshal(),
-						Private:  pem.EncodeToMemory(privPEM),
-						Provider: ctx.String("idp"),
-						errorf:   a.term.Errorf,
+
+					if err := a.generateKey(name, passphrase, ctx.String("idp"), ctx.String("type"), ctx.Int("bits")); err != nil {
+						return err
 					}
 					if err := a.saveKeys(); err != nil {
 						return err

--- a/go/internal/start.go
+++ b/go/internal/start.go
@@ -70,7 +70,10 @@ func Start(this js.Value, args []js.Value) (result any) {
 	cfg.Term.Call("writeln", "\x1b[32m╔════════════════════════════════════╗\x1b[0m")
 	cfg.Term.Call("writeln", "\x1b[32m║ SSH TERM \x1b[4;34mgithub.com/c2FmZQ/sshterm\x1b[0;32m ║\x1b[0m")
 	cfg.Term.Call("writeln", "\x1b[32m╚════════════════════════════════════╝\x1b[0m")
-	cfg.Term.Call("writeln", "\x1b[32mWelcome! Type \x1b[1mhelp\x1b[0;32m for a list of commands\x1b[0m\n")
+	if cfg.AutoConnect == nil {
+		cfg.Term.Call("writeln", "\x1b[32mWelcome! Type \x1b[1mhelp\x1b[0;32m for a list of commands\x1b[0m")
+	}
+	cfg.Term.Call("writeln", "")
 
 	return jsutil.NewPromise(func() (any, error) {
 		defer func() {

--- a/go/internal/start.go
+++ b/go/internal/start.go
@@ -26,9 +26,11 @@
 package internal
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"syscall/js"
 
 	"github.com/c2FmZQ/sshterm/internal/app"
@@ -52,28 +54,36 @@ func Start(this js.Value, args []js.Value) (result any) {
 	}
 	arg := args[0]
 
-	if t := arg.Get("term"); t.Type() != js.TypeObject {
+	term := arg.Get("term")
+	if term.Type() != js.TypeObject {
 		return errors.New("term value is missing")
 	}
+	arg.Delete("term")
 
-	cfg := &app.Config{
-		Term: arg.Get("term"),
+	jsArg := js.Global().Get("JSON").Call("stringify", arg).String()
+	var cfg app.Config
+	if err := json.Unmarshal([]byte(jsArg), &cfg); err != nil {
+		return fmt.Errorf("json.Unmarshal: %w", err)
 	}
+
+	cfg.Term = term
 	cfg.Term.Call("writeln", "\x1b[32m╔════════════════════════════════════╗\x1b[0m")
 	cfg.Term.Call("writeln", "\x1b[32m║ SSH TERM \x1b[4;34mgithub.com/c2FmZQ/sshterm\x1b[0;32m ║\x1b[0m")
 	cfg.Term.Call("writeln", "\x1b[32m╚════════════════════════════════════╝\x1b[0m")
 	cfg.Term.Call("writeln", "\x1b[32mWelcome! Type \x1b[1mhelp\x1b[0;32m for a list of commands\x1b[0m\n")
 
 	return jsutil.NewPromise(func() (any, error) {
-		a, err := app.New(cfg)
+		defer func() {
+			fmt.Fprintf(os.Stderr, "Start Promise return\n")
+		}()
+		a, err := app.New(&cfg)
 		if err != nil {
 			return nil, err
 		}
 		for {
 			if err = a.Run(); err != io.EOF {
-				break
+				return "exited", err
 			}
 		}
-		return "exited", err
 	})
 }

--- a/go/internal/tests/app_test.go
+++ b/go/internal/tests/app_test.go
@@ -241,6 +241,7 @@ func TestSSH(t *testing.T) {
 		{Type: "3\n", Expect: "Password: "},
 		{Type: "password\n", Expect: "remote> "},
 		{Type: "exit\n", Expect: prompt},
+		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "keys generate test\n", Expect: "Enter passphrase"},
 		{Type: "foobar\n", Expect: "Re-enter the same passphrase"},
@@ -257,12 +258,15 @@ func TestSSH(t *testing.T) {
 		{Type: "ssh -i test testuser@test-server\n", Expect: "Enter passphrase for test:"},
 		{Type: "foobar\n", Expect: "remote> "},
 		{Type: "exit\n", Expect: prompt},
+		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "agent add test\n", Expect: "Enter passphrase for test:"},
 		{Type: "foobar\n", Expect: prompt},
 		{Type: "ssh testuser@test-server\n", Expect: "remote> "},
 		{Type: "exit\n", Expect: prompt},
+		{Wait: time.Second, Type: "\n\n"},
 		{Type: "ssh testuser@test-server foo bar\n", Expect: "exec: foo bar"},
+		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "file upload testuser@test-server:.\n", Expect: "100%"},
 
@@ -349,6 +353,7 @@ func TestHostCerts(t *testing.T) {
 		{Type: "ssh testuser@test-server foo\n", Expect: `Host certificate is trusted`},
 		{Expect: "Password: "},
 		{Type: "password\n", Expect: "exec: foo"},
+		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "ep add fooserver websocket?cert=true\n", Expect: prompt},
 		{Type: "ssh testuser@fooserver foo\n", Expect: `(?s)Host certificate is NOT trusted.*Choice>`},
@@ -357,13 +362,16 @@ func TestHostCerts(t *testing.T) {
 		{Type: "ssh testuser@fooserver foo\n", Expect: `(?s)Host certificate is NOT trusted.*Choice>`},
 		{Type: "2\n", Expect: "Password: "},
 		{Type: "password\n", Expect: "exec: foo"},
+		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "ssh testuser@fooserver foo\n", Expect: `(?s)Host certificate is NOT trusted.*Choice>`},
 		{Type: "3\n", Expect: "Password: "},
 		{Type: "password\n", Expect: "exec: foo"},
+		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "ssh testuser@fooserver foo\n", Expect: "Password: "},
 		{Type: "password\n", Expect: "exec: foo"},
+		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "ca list\n", Expect: "fooserver"},
 

--- a/go/internal/tests/app_test.go
+++ b/go/internal/tests/app_test.go
@@ -241,7 +241,6 @@ func TestSSH(t *testing.T) {
 		{Type: "3\n", Expect: "Password: "},
 		{Type: "password\n", Expect: "remote> "},
 		{Type: "exit\n", Expect: prompt},
-		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "keys generate test\n", Expect: "Enter passphrase"},
 		{Type: "foobar\n", Expect: "Re-enter the same passphrase"},
@@ -258,15 +257,12 @@ func TestSSH(t *testing.T) {
 		{Type: "ssh -i test testuser@test-server\n", Expect: "Enter passphrase for test:"},
 		{Type: "foobar\n", Expect: "remote> "},
 		{Type: "exit\n", Expect: prompt},
-		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "agent add test\n", Expect: "Enter passphrase for test:"},
 		{Type: "foobar\n", Expect: prompt},
 		{Type: "ssh testuser@test-server\n", Expect: "remote> "},
 		{Type: "exit\n", Expect: prompt},
-		{Wait: time.Second, Type: "\n\n"},
 		{Type: "ssh testuser@test-server foo bar\n", Expect: "exec: foo bar"},
-		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "file upload testuser@test-server:.\n", Expect: "100%"},
 
@@ -353,7 +349,6 @@ func TestHostCerts(t *testing.T) {
 		{Type: "ssh testuser@test-server foo\n", Expect: `Host certificate is trusted`},
 		{Expect: "Password: "},
 		{Type: "password\n", Expect: "exec: foo"},
-		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "ep add fooserver websocket?cert=true\n", Expect: prompt},
 		{Type: "ssh testuser@fooserver foo\n", Expect: `(?s)Host certificate is NOT trusted.*Choice>`},
@@ -362,16 +357,13 @@ func TestHostCerts(t *testing.T) {
 		{Type: "ssh testuser@fooserver foo\n", Expect: `(?s)Host certificate is NOT trusted.*Choice>`},
 		{Type: "2\n", Expect: "Password: "},
 		{Type: "password\n", Expect: "exec: foo"},
-		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "ssh testuser@fooserver foo\n", Expect: `(?s)Host certificate is NOT trusted.*Choice>`},
 		{Type: "3\n", Expect: "Password: "},
 		{Type: "password\n", Expect: "exec: foo"},
-		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "ssh testuser@fooserver foo\n", Expect: "Password: "},
 		{Type: "password\n", Expect: "exec: foo"},
-		{Wait: time.Second, Type: "\n\n"},
 
 		{Type: "ca list\n", Expect: "fooserver"},
 

--- a/go/internal/tests/main_test.go
+++ b/go/internal/tests/main_test.go
@@ -38,6 +38,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c2FmZQ/sshterm/config"
 	"github.com/c2FmZQ/sshterm/internal/app"
 	"github.com/c2FmZQ/sshterm/internal/jsutil"
 )
@@ -87,8 +88,10 @@ func start(this js.Value, args []js.Value) any {
 	fileDownloader = &downloader{}
 
 	appConfig = &app.Config{
-		Term:         arg.Get("term"),
-		DBName:       "sshtermtest",
+		Term: arg.Get("term"),
+		Config: config.Config{
+			DBName: "sshtermtest",
+		},
 		UploadHook:   fileUploader.upload,
 		DownloadHook: fileDownloader.download,
 		StreamHook:   fileDownloader.stream,

--- a/go/internal/tests/main_test.go
+++ b/go/internal/tests/main_test.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sync"
 	"syscall/js"
@@ -56,6 +57,13 @@ var (
 func TestMain(m *testing.M) {
 	flag.Parse()
 	flag.Set("test.failfast", "true")
+	loc, err := url.Parse(js.Global().Get("location").Get("href").String())
+	if err != nil {
+		panic("location.href:" + err.Error())
+	}
+	if run := loc.Query().Get("run"); run != "" {
+		flag.Set("test.run", run)
+	}
 	sshApp := js.Global().Get("sshApp")
 	if sshApp.Type() != js.TypeObject {
 		panic("sshApp object not found")

--- a/go/internal/tests/preset_test.go
+++ b/go/internal/tests/preset_test.go
@@ -97,7 +97,8 @@ func TestPresetAuthorities(t *testing.T) {
 	fp := ssh.FingerprintSHA256(key)
 
 	if err := json.Unmarshal(
-		[]byte(`{"certificateAuthorities": [{
+		[]byte(`{
+			"certificateAuthorities": [{
 				"name": "testca",
 				"publicKey": "`+strings.TrimSpace(string(caKey))+`",
 				"hostnames": ["*.example.com"]}
@@ -105,7 +106,8 @@ func TestPresetAuthorities(t *testing.T) {
 			"endpoints": [{
 				"name": "myserver.example.com",
 				"url": "./websocket?cert=true"
-			}]}`),
+			}]
+		}`),
 		&cfg,
 	); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
@@ -170,7 +172,8 @@ func TestPresetKeys(t *testing.T) {
 	}
 
 	if err := json.Unmarshal(
-		[]byte(`{"certificateAuthorities": [{
+		[]byte(`{
+			"certificateAuthorities": [{
 				"name": "testca",
 				"publicKey": "`+strings.TrimSpace(string(caKey))+`",
 				"hostnames": ["*.example.com"]}
@@ -183,7 +186,8 @@ func TestPresetKeys(t *testing.T) {
 				"name": "foo",
 				"identityProvider": "./cert",
 				"addToAgent": true
-			}]}`),
+			}]
+		}`),
 		&cfg,
 	); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)

--- a/go/internal/tests/preset_test.go
+++ b/go/internal/tests/preset_test.go
@@ -1,0 +1,151 @@
+// MIT License
+//
+// Copyright (c) 2024 TTBT Enterprises LLC
+// Copyright (c) 2024 Robin Thellend <rthellend@rthellend.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build wasm
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/c2FmZQ/sshterm/internal/app"
+)
+
+func TestPresetPersist(t *testing.T) {
+	for _, tc := range []bool{true, false} {
+		t.Run(fmt.Sprintf("Persist=%v", tc), func(t *testing.T) {
+			cfg := *appConfig
+			cfg.Persist = &tc
+			cfg.Term.Call("writeln", t.Name())
+			a, err := app.New(&cfg)
+			if err != nil {
+				t.Fatalf("app.New: %v", err)
+			}
+			result := make(chan error)
+			go func() {
+				result <- a.Run()
+			}()
+
+			var expect string
+			if tc {
+				expect = "The database is persisted to local storage."
+			} else {
+				expect = "The database is NOT persisted to local storage."
+			}
+			script(t, []line{
+				{Type: "db persist on\n", Expect: expect},
+				{Type: "db persist off\n", Expect: expect},
+				{Type: "db persist toggle\n", Expect: expect},
+				{Type: "db persist\n", Expect: expect},
+				{Expect: prompt},
+				{Type: "exit\n"},
+			})
+			if err := <-result; err != nil {
+				t.Fatalf("Run(): %v", err)
+			}
+		})
+	}
+}
+
+func TestPresetAuthorities(t *testing.T) {
+	cfg := *appConfig
+	cfg.Term.Call("writeln", t.Name())
+
+	resp, err := http.Get("/cakey")
+	if err != nil {
+		t.Fatalf("/cakey: %v", err)
+	}
+	defer resp.Body.Close()
+
+	caKey, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Body: %v", err)
+	}
+	key, _, _, _, err := ssh.ParseAuthorizedKey(caKey)
+	if err != nil {
+		t.Fatalf("ssh.ParseAuthorizedKey: %v", err)
+	}
+	fp := ssh.FingerprintSHA256(key)
+
+	if err := json.Unmarshal(
+		[]byte(`{"certificateAuthorities": [{
+				"name": "testca",
+				"publicKey": "`+strings.TrimSpace(string(caKey))+`",
+				"hostnames": ["*.example.com"]}
+			],
+			"endpoints": [{
+				"name": "myserver.example.com",
+				"url": "./websocket?cert=true"
+			}]}`),
+		&cfg,
+	); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	a, err := app.New(&cfg)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	result := make(chan error)
+	go func() {
+		result <- a.Run()
+	}()
+
+	script(t, []line{
+		{Type: "db persist on\n", Expect: prompt},
+		{Type: "ca list\n", Expect: `testca ` + regexp.QuoteMeta(fp) + ` \*\.example\.com`},
+		{Type: "ssh testuser@myserver.example.com foo\n", Expect: "Password: "},
+		{Type: "password\n", Expect: "exec: foo"},
+		{Type: "ca remove-hostname testca *.example.com\n", Expect: prompt},
+		{Type: "ca add-hostname testca foobar\n", Expect: prompt},
+		{Type: "ca list\n", Expect: `testca ` + regexp.QuoteMeta(fp) + ` foobar`},
+		{Type: "exit\n"},
+	})
+	if err := <-result; err != nil {
+		t.Fatalf("Run(): %v", err)
+	}
+
+	if a, err = app.New(&cfg); err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	go func() {
+		result <- a.Run()
+	}()
+
+	script(t, []line{
+		{Type: "ca list\n", Expect: `testca ` + regexp.QuoteMeta(fp) + ` \*\.example\.com`},
+		{Type: "ssh testuser@myserver.example.com foo\n", Expect: "Password: "},
+		{Type: "password\n", Expect: "exec: foo"},
+		{Type: "exit\n"},
+	})
+	if err := <-result; err != nil {
+		t.Fatalf("Run(): %v", err)
+	}
+}

--- a/go/internal/tests/preset_test.go
+++ b/go/internal/tests/preset_test.go
@@ -179,7 +179,7 @@ func TestPresetKeys(t *testing.T) {
 				"name": "myserver.example.com",
 				"url": "./websocket?cert=true"
 			}],
-		        "generateKeys": [{
+			"generateKeys": [{
 				"name": "foo",
 				"identityProvider": "./cert",
 				"addToAgent": true


### PR DESCRIPTION
The app can now be configured with default Certificate Authorities, WebSocket endpoints, etc.

See `config/config.go` and `docroot/config.json.example`